### PR TITLE
Update trust-validator.py

### DIFF
--- a/trust-validator.py
+++ b/trust-validator.py
@@ -22,7 +22,7 @@ class SafeTicketValidator:
         Helper function to safely send TGS request using sendReceive
         """
         try:
-            tgs, cipher, _ = getKerberosTGS(server_name, domain, dc_ip, tgt, cipher, session_key)
+            tgs, cipher, _, _ = getKerberosTGS(server_name, domain, dc_ip, tgt, cipher, session_key)
             return tgs
         except Exception as e:
             print(f"[!] Error sending TGS request: {str(e)}")


### PR DESCRIPTION
For me the script only works with specifying the UPN.
However, the script would fail like this:
![image](https://github.com/user-attachments/assets/47575d7f-0d4d-40f4-b0e0-32da5a75ed54)

The returned values are 4, hence the addition.
Afterwards everything worked in my case.
![image](https://github.com/user-attachments/assets/87830277-c8e8-411a-806a-6369f528e14c)
